### PR TITLE
Updating to allow Eastern Pacific TC Linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # QTrack: An African Easterly Wave Tracker
-**Version: 0.0.3**
+**Version: 0.0.4**
 
 The AEW tracker was developed by **Quinton Lawton**, currently affiliated with the NSF National Center for Atmospheric Research (NSF NCAR). This python module was developed with the support of **Zachary Moon** (NOAA ARL/Texas A&M University) and **Kelly Núñez Ocasio** (Texas A&M University).  
 

--- a/qtrack/__init__.py
+++ b/qtrack/__init__.py
@@ -2,7 +2,7 @@
 QTrack - African Easterly Wave Tracking in Model and Reanalysis Data
 """
 
-__version__ = "0.0.3"
+__version__ = "0.0.4"
 
 from .core import COMPUTE_CURV_VORT_NON_DIV_UPDATE, download_examples, prep_data
 

--- a/qtrack/tracking.py
+++ b/qtrack/tracking.py
@@ -1930,7 +1930,7 @@ def run_postprocessing(
     linked_TC_wave_time = []
 
     if pair_with_TC:
-        hurdat_atl = tracks.TrackDataset(basin="north_atlantic", source="hurdat", include_btk=True)
+        hurdat_atl = tracks.TrackDataset(basin="basin", source="hurdat", include_btk=True)
         season_pull = hurdat_atl.get_season(int(year_used))
         TC_id_list = season_pull.summary()["id"]
         # print(TC_id_list)

--- a/qtrack/tracking.py
+++ b/qtrack/tracking.py
@@ -1930,7 +1930,7 @@ def run_postprocessing(
     linked_TC_wave_time = []
 
     if pair_with_TC:
-        hurdat_atl = tracks.TrackDataset(basin="basin", source="hurdat", include_btk=True)
+        hurdat_atl = tracks.TrackDataset(basin="both", source="hurdat", include_btk=True)
         season_pull = hurdat_atl.get_season(int(year_used))
         TC_id_list = season_pull.summary()["id"]
         # print(TC_id_list)


### PR DESCRIPTION
Previous update (version 0.0.3) had an error for TC linking, and that has been fixed. The code should currently be able to link AEWs with TCs in both the Atlantic and Pacific basin.